### PR TITLE
TODOユースケースの追加

### DIFF
--- a/src/__test__/todos/testData.ts
+++ b/src/__test__/todos/testData.ts
@@ -1,3 +1,9 @@
 import {todo} from '../../db/json/data/todo';
+import {TodoType} from '../../db/json/types/todo';
+import {TodoEntity} from '../../entity/todo/todo';
 
-export const testTodos = new Array(2).fill(todo);
+export const testDbTodos: TodoType[] = new Array(2).fill(todo);
+export const testApplicationTodos: TodoEntity[] = new Array(2).fill({
+  ...todo,
+  deadlineDate: new Date(),
+});

--- a/src/driver/todo/todoDriver.test.ts
+++ b/src/driver/todo/todoDriver.test.ts
@@ -5,7 +5,7 @@
 
 import axios from 'axios';
 import {TodoDriver} from './todoDriver';
-import {testTodos} from '../../__test__/todos/testData';
+import {testDbTodos} from '../../__test__/todos/testData';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -22,7 +22,7 @@ describe('TodoDriver', () => {
 
   describe('fetchAll', () => {
     it('APIアクセスが成功したら、TODOが2つ返却される', async () => {
-      const response = {data: testTodos};
+      const response = {data: testDbTodos};
       mockedAxios.get.mockResolvedValue(response);
 
       const fetchTodos = await todoDriverInstance.fetchAll();

--- a/src/repository/todo/todoRepository.test.ts
+++ b/src/repository/todo/todoRepository.test.ts
@@ -1,6 +1,6 @@
 import {TodoRepository} from './todoRepository';
 import {TodoDriver} from '../../driver/todo/todoDriver';
-import {testTodos} from '../../__test__/todos/testData';
+import {testDbTodos} from '../../__test__/todos/testData';
 
 const todoDriverInstance = new TodoDriver();
 const todoRepositoryInstance = new TodoRepository(todoDriverInstance);
@@ -17,7 +17,7 @@ describe('TodoRepository', () => {
     it('todoDriver.fetchAllが成功した場合、取得したデータと同じ数だけdeadlineを追加したデータを返却する', async () => {
       const spyTodoDriver = jest
         .spyOn(todoDriverInstance, 'fetchAll')
-        .mockResolvedValue(testTodos);
+        .mockResolvedValue(testDbTodos);
 
       const todos = await todoRepositoryInstance.fetchAll();
 

--- a/src/repository/todo/todoRepository.ts
+++ b/src/repository/todo/todoRepository.ts
@@ -1,7 +1,12 @@
 import {TodoType} from '../../db/json/types/todo';
 import {ITodoDriver} from '../../driver/todo/todoDriver';
+import {TodoEntity} from '../../entity/todo/todo';
 
-export class TodoRepository {
+export interface ITodoRepository {
+  fetchAll: () => Promise<TodoEntity[]>;
+}
+
+export class TodoRepository implements ITodoRepository {
   private readonly todoDriver: ITodoDriver;
   constructor(todoDriver: ITodoDriver) {
     this.todoDriver = todoDriver;
@@ -20,7 +25,7 @@ export class TodoRepository {
     }
   };
 
-  private convertForEntity = (todos: TodoType[]) => {
+  private convertForEntity = (todos: TodoType[]): TodoEntity[] => {
     return todos.map((todo) => ({
       ...todo,
       deadlineDate: new Date(),

--- a/src/use-case/todo/todoUseCase.test.ts
+++ b/src/use-case/todo/todoUseCase.test.ts
@@ -1,0 +1,43 @@
+import {TodoDriver} from '../../driver/todo/todoDriver';
+import {TodoRepository} from '../../repository/todo/todoRepository';
+import {testApplicationTodos} from '../../__test__/todos/testData';
+import {TodoUseCase} from './todoUseCase';
+
+const todoDriverInstance = new TodoDriver();
+const todoRepositoryInstance = new TodoRepository(todoDriverInstance);
+const todoUseCaseInstance = new TodoUseCase(todoRepositoryInstance);
+
+describe('TodoUseCase', () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchAll', () => {
+    it('todoRepository.fetchAllが成功した場合、TODOが2つ返却される', async () => {
+      const spyTodoRepository = jest
+        .spyOn(todoRepositoryInstance, 'fetchAll')
+        .mockResolvedValue(testApplicationTodos);
+
+      const todos = await todoUseCaseInstance.fetchAll();
+
+      expect(spyTodoRepository).toHaveBeenCalledTimes(1);
+      expect(todos.length).toBe(2);
+    });
+
+    it('todoRepository.fetchAllが失敗した場合、エラー「todo repository failed to fetch todos.」がthrowされる', async () => {
+      const spyTodoRepository = jest
+        .spyOn(todoRepositoryInstance, 'fetchAll')
+        .mockRejectedValue(() => {
+          throw new Error();
+        });
+
+      await expect(todoUseCaseInstance.fetchAll()).rejects.toThrow(
+        'todo use case failed to fetch todos.'
+      );
+      expect(spyTodoRepository).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/use-case/todo/todoUseCase.ts
+++ b/src/use-case/todo/todoUseCase.ts
@@ -1,0 +1,23 @@
+import {ITodoRepository} from '../../repository/todo/todoRepository';
+
+/**
+ * アプリケーションにおける動作を定義
+ */
+export class TodoUseCase {
+  private readonly todoRepository: ITodoRepository;
+  constructor(todoRepository: ITodoRepository) {
+    this.todoRepository = todoRepository;
+  }
+
+  /**
+   * 全てのtodoを取得
+   */
+  public fetchAll = async () => {
+    try {
+      const todos = await this.todoRepository.fetchAll();
+      return todos;
+    } catch (error) {
+      throw new Error('todo use case failed to fetch todos.');
+    }
+  };
+}


### PR DESCRIPTION
## やったこと
- todo use caseの追加
- todo use caseのテスト記述

## 所感
このサンプル、似た処理ばっかりでクラス名だけ違って関数名が一緒だから、何をしているのかぱっと見わかりにくいな。。
とりあえずuse caseに関しては、アプリケーションにおける動作を定義するよ、ってコメントアウトしておいた。

相変わらずテストは書きやすいと思う。