### PR TITLE
Todo Presenter/ Viewの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^13.2.0",
     "@types/jest": "^27.5.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",

--- a/src/__test__/todos/testData.ts
+++ b/src/__test__/todos/testData.ts
@@ -2,6 +2,11 @@ import {todo} from '../../db/json/data/todo';
 import {TodoType} from '../../db/json/types/todo';
 import {TodoEntity} from '../../entity/todo/todo';
 
+export const applicationTodo: TodoEntity = {
+  ...todo,
+  deadlineDate: new Date(),
+};
+
 export const testDbTodos: TodoType[] = new Array(2).fill(todo);
 export const testApplicationTodos: TodoEntity[] = new Array(2).fill({
   ...todo,

--- a/src/presenter/hooks/todo/useFetchTodos.test.ts
+++ b/src/presenter/hooks/todo/useFetchTodos.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// テストファイルの上部にこれやれば良いっぽい。
+// React Testing Library のexmapleには@testing-library/jest-domをinstallする方法も載っていた。
+// 依存先は最小限にしたい&React Testing LibraryのexampleにはJest27ならこっちでも良いって書いてあった。
+// から、jestの環境を変えるだけで良い上記を使用する。
+// ref: https://jestjs.io/docs/configuration#testenvironment-string
+
+import axios from 'axios';
+import {testDbTodos} from '../../../__test__/todos/testData';
+import {renderHook, waitFor} from '@testing-library/react';
+import {useFetchTodos} from './useFetchTodos';
+
+describe('useFetchTodos', () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('todoの取得に成功したら、todoが2個取得できる', async () => {
+    const response = {data: testDbTodos};
+    const spyAxiosGet = jest.spyOn(axios, 'get').mockResolvedValue(response);
+
+    const {result} = renderHook(() => useFetchTodos());
+    await waitFor(() => expect(spyAxiosGet).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.todos.length).toBe(2));
+  });
+
+  it('todoの取得に失敗したら、todoが0個取得できる', async () => {
+    const spyAxiosGet = jest.spyOn(axios, 'get').mockRejectedValue(() => {
+      throw new Error();
+    });
+    const {result} = renderHook(() => useFetchTodos());
+    await waitFor(() => expect(spyAxiosGet).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.todos.length).toBe(0));
+  });
+});

--- a/src/presenter/hooks/todo/useFetchTodos.ts
+++ b/src/presenter/hooks/todo/useFetchTodos.ts
@@ -1,0 +1,35 @@
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {TodoDriver} from '../../../driver/todo/todoDriver';
+import {TodoEntity} from '../../../entity/todo/todo';
+import {TodoRepository} from '../../../repository/todo/todoRepository';
+import {TodoUseCase} from '../../../use-case/todo/todoUseCase';
+
+export const useFetchTodos = () => {
+  const todoDriverInstance = useMemo(() => new TodoDriver(), []);
+  const todoRepositoryInstance = useMemo(
+    () => new TodoRepository(todoDriverInstance),
+    [todoDriverInstance]
+  );
+  const todoUseCaseInstance = useMemo(
+    () => new TodoUseCase(todoRepositoryInstance),
+    [todoRepositoryInstance]
+  );
+
+  const [todos, setTodos] = useState<TodoEntity[]>([]);
+
+  const fetchTodos = useCallback(async () => {
+    return await todoUseCaseInstance
+      .fetchAll()
+      .then((res) => setTodos(res))
+      .catch((error) => console.log(error));
+  }, [todoUseCaseInstance]);
+
+  useEffect(() => {
+    const unsub = fetchTodos();
+    return () => {
+      unsub;
+    };
+  }, [fetchTodos]);
+
+  return {todos};
+};

--- a/src/view/components/features/todo/Todo.test.tsx
+++ b/src/view/components/features/todo/Todo.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {applicationTodo} from '../../../../__test__/todos/testData';
+import {Todo} from './Todo';
+import {TodoEntity} from '../../../../entity/todo/todo';
+import '@testing-library/jest-dom';
+
+describe('Todo', () => {
+  it('propsで渡されたtodoのtitleを表示する', () => {
+    const todo: TodoEntity = {...applicationTodo, title: 'test title'};
+    render(<Todo todo={todo} />);
+
+    expect(screen.getByTestId('todo-component')).toHaveTextContent(
+      'test title'
+    );
+  });
+});

--- a/src/view/components/features/todo/Todo.tsx
+++ b/src/view/components/features/todo/Todo.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {TodoEntity} from '../../../../entity/todo/todo';
+
+interface P {
+  todo: TodoEntity;
+}
+
+export const Todo = ({todo}: P) => {
+  return <div data-testid="todo-component">{todo.title}</div>;
+};

--- a/src/view/components/features/todo/TodoList.test.tsx
+++ b/src/view/components/features/todo/TodoList.test.tsx
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {testApplicationTodos} from '../../../../__test__/todos/testData';
+import {TodoList} from './TodoList';
+
+describe('TodoList', () => {
+  it('propsで渡された数だけ、Todoを描画する', () => {
+    render(<TodoList todos={testApplicationTodos} />);
+    expect(screen.getAllByTestId('todo-component').length).toBe(
+      testApplicationTodos.length
+    );
+  });
+});

--- a/src/view/components/features/todo/TodoList.tsx
+++ b/src/view/components/features/todo/TodoList.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {TodoEntity} from '../../../../entity/todo/todo';
+import {Todo} from './Todo';
+
+interface P {
+  todos: TodoEntity[];
+}
+
+export const TodoList = ({todos}: P) => {
+  return (
+    <div>
+      {todos.map((todo, index) => (
+        <Todo key={`${todo.userId}-${todo.id}-${index}`} todo={todo} />
+      ))}
+    </div>
+  );
+};

--- a/src/view/components/features/todo/TodoPresenter.tsx
+++ b/src/view/components/features/todo/TodoPresenter.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import {TodoList} from './TodoList';
+import {useFetchTodos} from '../../../../presenter/hooks/todo/useFetchTodos';
+
+export const TodoPresenter = () => {
+  const {todos} = useFetchTodos();
+
+  return <TodoList todos={todos} />;
+};


### PR DESCRIPTION
## やったこと
- todo presenter の追加
- todo presenter のテスト記述
- todo view の追加
- todo view のテスト記述
  - testing libraryの導入

## 所感
- viewのロジックと完全に分離するために、presenterの階層を作ってそこをカスタムフックで実装することにした。そうすることで、大きくなりがちなviewファイルがかなりコンパクトにまとまった
- コンパクトにまとまったから、テストしやすい
- dom取得するなら `data-test-id` が一番早いかな
- `<Todo data-testid="todo-component" />` ってやってもdata-testidは取得できないことに気づいた。Todoコンポーネントの最上層のdivタグにつけねば。
- usecaseを毎回呼び出すのがだるくなってきたら、コンテキストとかに移すと良さそう
  - reduxを導入しても良いかもしれないが、usecase はある程度限られた範囲での使用になると考えられるため
- react関連のtestファイル上部に毎回 `@jest-environment jsdom` ってやるのつらいな。。
- この構成だとカスタムフックのテストに若干難あり。axiosをモックするって方法で今回は回避したけど、どういう感じで回避するのが良いかな。。
  - usecase層で定義したモデルが状態を持たないなら良いんだけど、repositoryのinterfaceに依存させる関係で、constructor関数を定義して状態を持つようにしている
  - &インスタンス化をカスタムフック内でやっている
  - その関係で、usecaseをモックしたいけど、ちょっとやり方出てこなかった。。。
  - だから渋々末端のaxiosをモックすることで回避をした
    - axiosはモックせずmswでサーバー立てるやり方の方が良さそう、って議論は違うPRでした。ので今度やる。