### PR TITLE
Presenter層のリファクタリング

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",
-    "husky": ">=6",
+    "husky": "^7.0.4",
     "jest": "^27.5.1",
     "lint-staged": ">=10",
     "prettier": "^2.6.2",

--- a/src/presenter/hooks/todo/useFetchTodos.ts
+++ b/src/presenter/hooks/todo/useFetchTodos.ts
@@ -1,20 +1,8 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
-import {TodoDriver} from '../../../driver/todo/todoDriver';
+import {useCallback, useEffect, useState} from 'react';
 import {TodoEntity} from '../../../entity/todo/todo';
-import {TodoRepository} from '../../../repository/todo/todoRepository';
 import {TodoUseCase} from '../../../use-case/todo/todoUseCase';
 
-export const useFetchTodos = () => {
-  const todoDriverInstance = useMemo(() => new TodoDriver(), []);
-  const todoRepositoryInstance = useMemo(
-    () => new TodoRepository(todoDriverInstance),
-    [todoDriverInstance]
-  );
-  const todoUseCaseInstance = useMemo(
-    () => new TodoUseCase(todoRepositoryInstance),
-    [todoRepositoryInstance]
-  );
-
+export const useFetchTodos = (todoUseCaseInstance: TodoUseCase) => {
   const [todos, setTodos] = useState<TodoEntity[]>([]);
 
   const fetchTodos = useCallback(async () => {

--- a/src/view/components/features/todo/TodoPresenter.tsx
+++ b/src/view/components/features/todo/TodoPresenter.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import {TodoList} from './TodoList';
-import {useFetchTodos} from '../../../../presenter/hooks/todo/useFetchTodos';
-
-export const TodoPresenter = () => {
-  const {todos} = useFetchTodos();
-
-  return <TodoList todos={todos} />;
-};

--- a/src/view/components/features/todo/TodoScreen.tsx
+++ b/src/view/components/features/todo/TodoScreen.tsx
@@ -1,0 +1,21 @@
+import React, {useMemo} from 'react';
+import {TodoList} from './TodoList';
+import {useFetchTodos} from '../../../../presenter/hooks/todo/useFetchTodos';
+import {TodoDriver} from '../../../../driver/todo/todoDriver';
+import {TodoRepository} from '../../../../repository/todo/todoRepository';
+import {TodoUseCase} from '../../../../use-case/todo/todoUseCase';
+
+export const TodoScreen = () => {
+  const todoDriverInstance = useMemo(() => new TodoDriver(), []);
+  const todoRepositoryInstance = useMemo(
+    () => new TodoRepository(todoDriverInstance),
+    [todoDriverInstance]
+  );
+  const todoUseCaseInstance = useMemo(
+    () => new TodoUseCase(todoRepositoryInstance),
+    [todoRepositoryInstance]
+  );
+  const {todos} = useFetchTodos(todoUseCaseInstance);
+
+  return <TodoList todos={todos} />;
+};


### PR DESCRIPTION
## やったこと
- presenter層（カスタムフック）のリファクタリング
  - カスタムフックの引数にユースケースのインスタンスを取るようにした
  - こうすることで、カスタムフック のテストを実施するときに、axiosをモックする必要がなくなった
  - driver層のテスト以外でaxiosがモックすることが、少し異常に感じられた
  - だから今回のリファクタリングを行った
- `TodoScreen.tsx` へと名称変更した